### PR TITLE
Add services to change/reset velocity multiplexer priorities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ add_message_files(FILES ARPair.msg
                         Waypoint.msg
                         WaypointList.msg)
 
-add_service_files(FILES WaypointListService.srv)
+add_service_files(FILES ChangeMuxPriority.srv ResetPendingMuxPriority.srv WaypointListService.srv)
 
 add_action_files(
   DIRECTORY action

--- a/srv/ChangeMuxPriority.srv
+++ b/srv/ChangeMuxPriority.srv
@@ -1,0 +1,8 @@
+uint8 LOWEST_PRIORITY=0
+uint8 HIGHEST_PRIORITY=255
+
+string topic    # The topic whose priority needs to be changed
+uint8 priority  # The priority to set for the topic
+bool permanent  # Priority change is permanent if set to true
+float32 timeout # Timeout only applies if priority change is not permanent
+---

--- a/srv/ResetPendingMuxPriority.srv
+++ b/srv/ResetPendingMuxPriority.srv
@@ -1,0 +1,2 @@
+string topic
+---


### PR DESCRIPTION
The following services are introduced:

- `ChangeMuxPriority.srv` : To temporarily/permanently change the priority of an input topic to the `yocs_cmd_vel_mux` velocity multiplexer. This is especially useful in situations where a transition from a higher priority to a lower priority topic is required without wanting to wait for the timeout period to expire

- `ResetPendingMuxPriority.srv` : This service allows for fast-forwarding a pending priority reset for an input topic. This might be required if the priority of a topic was lowered through the `ChangeMuxPriority` service temporarily, and we want to immediately have the topic reset to its original priority. 